### PR TITLE
BSB-Acre

### DIFF
--- a/AcrePortalExtract.py
+++ b/AcrePortalExtract.py
@@ -1,0 +1,57 @@
+import os
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+
+# URLs
+LOGIN_URL = 'https://licitacao.ac.gov.br/editais/check_login.php'
+LISTA_URL = 'https://licitacao.ac.gov.br/editais/index.php?task=lista_editais'
+DESTINO_PASTA = 'pdfs_editais'
+
+# Credenciais
+USUARIO = 'CPF/CNPJ'
+SENHA = 'SENHA' # geralmente 4 ou 5 digitos
+
+# Cria sessão persistente
+sessao = requests.Session()
+
+# Payload do formulário
+payload = {
+    'cnpj': USUARIO,
+    'senha': SENHA,
+    'task': 'check_login',
+    'option': 'com_licitacoes'
+}
+
+# 1. Login POST
+res_login = sessao.post(LOGIN_URL, data=payload)
+
+# 2. Verifica sucesso
+if "index.php?task=lista_editais" not in res_login.text and "sair" not in res_login.text.lower():
+    print("Conteúdo recebido (início):\n", res_login.text[:1000])
+    raise Exception("❌ Login falhou — verifique usuário/senha ou payload")
+
+# 3. Vai para a página da lista de editais
+res_lista = sessao.get(LISTA_URL)
+soup = BeautifulSoup(res_lista.text, 'html.parser')
+
+# 4. Extrai os links dos PDFs
+pdf_links = [urljoin(LISTA_URL, a['href']) for a in soup.find_all('a', href=True) if a['href'].lower().endswith('.pdf')]
+
+print(f"🔎 {len(pdf_links)} PDF(s) encontrados.")
+
+# 5. Baixa os PDFs
+os.makedirs(DESTINO_PASTA, exist_ok=True)
+
+for link in pdf_links:
+    nome_arquivo = os.path.basename(link.split('/')[-1])
+    caminho = os.path.join(DESTINO_PASTA, nome_arquivo)
+
+    if not os.path.exists(caminho):
+        print(f"⬇️  Baixando: {nome_arquivo}")
+        r = sessao.get(link)
+        with open(caminho, 'wb') as f:
+            f.write(r.content)
+    else:
+        print(f"✅ Já existe: {nome_arquivo}")
+


### PR DESCRIPTION
script para baixar as licitações do portal do Acre (que não inclui api por falta de infraestrutura do Estado, já com a raspagem dos dados, os arquivos são baixos em .pdf, depois preciso encontrar alternativas para integrar esses PDF's de licitação ao BSB. Por padrão o Site só disponibiliza em PDF.)

# Descrição

script para baixar as licitações do portal do Acre

✅ Checklist

O código segue os padrões do projeto
Permite autenticação e download robusto via requests.Session()
Cria pastas automáticas para armazenamento (pdfs_editais)
Pode ser integrado ao pipeline de análise e banco de dados
(opcional) Adicionei testes unitários ou CLI
(opcional) Atualizei a documentação correspondente

## Como Testar

Descreva como testar as mudanças feitas. Liste os passos necessários para que outros desenvolvedores possam replicar o teste.

python3 arquivo.py

## Issues Relacionadas

Falta de integração aos PDF's do portal do Acre, falta converter para CSV.

Resolves: #123
Relacionado: #456

## Outras Observações

Adicione quaisquer outras observações ou contexto adicional sobre a mudança aqui.
